### PR TITLE
Skip sanitizing the request body if the charset is non-utf-8

### DIFF
--- a/lib/rack/utf8_sanitizer.rb
+++ b/lib/rack/utf8_sanitizer.rb
@@ -2,6 +2,7 @@
 
 require 'uri'
 require 'stringio'
+require 'rack/request'
 
 module Rack
   class UTF8Sanitizer
@@ -126,6 +127,10 @@ module Rack
         end
       end
       return unless @sanitizable_content_types.any? {|type| content_type == type }
+
+      charset = Rack::Request.new(env).content_charset
+      return if charset && charset.downcase != 'utf-8'
+
       uri_encoded = URI_ENCODED_CONTENT_TYPES.any? {|type| content_type == type}
 
       if env['rack.input']

--- a/lib/rack/utf8_sanitizer.rb
+++ b/lib/rack/utf8_sanitizer.rb
@@ -116,19 +116,11 @@ module Rack
     end
 
     def sanitize_rack_input(env)
-      # https://github.com/rack/rack/blob/master/lib/rack/request.rb#L42
-      # Logic borrowed from Rack::Request#media_type,#media_type_params,#content_charset
-      # Ignoring charset in content type.
-      if content_type = env['CONTENT_TYPE']
-        content_type = content_type.split(/[;,]/, 2).first
-        if content_type
-          content_type.strip!
-          content_type.downcase!
-        end
-      end
+      request = Rack::Request.new(env)
+      content_type = request.media_type
       return unless @sanitizable_content_types.any? {|type| content_type == type }
 
-      charset = Rack::Request.new(env).content_charset
+      charset = request.content_charset
       return if charset && charset.downcase != 'utf-8'
 
       uri_encoded = URI_ENCODED_CONTENT_TYPES.any? {|type| content_type == type}


### PR DESCRIPTION
Fixes #83

With this change, sanitizing the request body will be skipped when the `charset` is other than UTF-8. This change should only affect requests that have a content-type header with non-utf-8 charset parameter.
